### PR TITLE
Remove indirection in create macro

### DIFF
--- a/lib/sitemap/dsl.ex
+++ b/lib/sitemap/dsl.ex
@@ -17,24 +17,16 @@ defmodule Sitemap.DSL do
   end
 
   defmacro create(contents) do
-    contents =
-      case contents do
-        [do: block] ->
-          quote do
-            Sitemap.Config.update @__use_resource__
-            unquote(block); fin
-          end
-        [do: block, use: false] ->
-          quote do
-            unquote(block); fin
-          end
-      end
-
-    contents = Macro.escape(contents, unquote: true)
-
-    Code.eval_quoted(quote do
-      unquote(contents)
-    end)
+    case contents do
+      [do: block] ->
+        quote do
+          Sitemap.Config.update @__use_resource__
+          unquote(block); fin()
+        end
+      [do: block, use: false] ->
+        quote do
+          unquote(block); fin()
+        end
+    end
   end
-
 end


### PR DESCRIPTION
`quote do unquote(contents) end` is the same as `contents`.

`Code.eval_quoted(Macro.escape(contents), [])` is the same as `contents`.

Keep in mind though one test fails because the block will no longer return
`{:ok, []}`, which was the result of the quoted expressions, but simply `:ok`.
You can keep the previous behaviour by returning `{:ok, []}` from the quoted
expressions but I would fix the test. :)
