### PR TITLE
added add_to_index method for custom urls in index sitemap

### DIFF
--- a/lib/sitemap/builders/indexfile.ex
+++ b/lib/sitemap/builders/indexfile.ex
@@ -23,6 +23,14 @@ defmodule Sitemap.Builders.Indexfile do
     incr_state :total_count, FileBuilder.state.link_count
   end
 
+  def add_to_index(link, options \\ []) do
+    content = Location.custom_url(link)
+      |> Indexurl.to_xml(options)
+      |> XmlBuilder.generate
+
+    add_state :content, content
+  end
+
   def write do
     s = state()
     content = Consts.xml_idxheader <> s.content <> Consts.xml_idxfooter

--- a/lib/sitemap/generator.ex
+++ b/lib/sitemap/generator.ex
@@ -13,6 +13,10 @@ defmodule Sitemap.Generator do
     end
   end
 
+  def add_to_index(link, options \\ []) do
+    Indexfile.add_to_index link, options
+  end
+
   def full do
     Indexfile.add
     FileBuilder.finalize_state

--- a/lib/sitemap/location.ex
+++ b/lib/sitemap/location.ex
@@ -14,6 +14,13 @@ defmodule Sitemap.Location do
     |> Path.expand
   end
 
+  def custom_url(link) do
+		conf = Sitemap.Config.get
+		conf.host
+			|> Path.join(conf.public_path)
+			|> Path.join(link)
+  end
+
   def url(name) do
     s = Config.get
     s.host

--- a/test/sitemap/generator_test.exs
+++ b/test/sitemap/generator_test.exs
@@ -35,6 +35,7 @@ defmodule Sitemap.GeneratorTest do
     end
   end
 
+  # TODO: write a proper test
   test "add_to_index function" do
     data = [lastmod: "lastmod", expires: "expires", changefreq: "changefreq", priority: 0.5]
     Sitemap.Builders.File.add("loc", data)


### PR DESCRIPTION
Hey!

While using this library i've run into the necessity to add some custom urls to the sitemap index, and didn't find any way to do that. 

I needed something like add_to_index in the Ruby gem https://github.com/kjvarga/sitemap_generator, so i implemented a very basic version.

Don't have much experience with elixir and tbh i didn't spend a lot of time on this, but would appreciate your feedback.