### PR TITLE
Writing Sitemaps to disk in UTF-8 mode

### DIFF
--- a/lib/sitemap/adapters/file.ex
+++ b/lib/sitemap/adapters/file.ex
@@ -14,9 +14,9 @@ defmodule Sitemap.Adapters.File do
 
     path = Location.path(name)
     if Regex.match?(~r/.gz$/, path) do
-      writefile(File.open!(path, [:write, :compressed]), data)
+      writefile(File.open!(path, [:write, :utf8, :compressed]), data)
     else
-      writefile(File.open!(path, [:write]), data)
+      writefile(File.open!(path, [:write, :utf8]), data)
     end
   end
 


### PR DESCRIPTION
Sitemaps are `UTF-8` encoded, however creating a sitemap with UTF-8 strings (not in the URL, but in titles/captions) raises an error. To reproduce, you can call this:

```elixir
def generate do
  create do
    add "index.html", images: [
      loc:   "http://example.com/image.jpg",
      title: "A UTF8 String: \u1F6FF"
    ]
  end
end
```

It will raise this error:

```
** (ErlangError) erlang error: :no_translation
       (stdlib) :io.put_chars(#PID<0.497.0>, :unicode, "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<urlset\n  xmlns:xsi='http://www.w3.org/2001/XMLSchema-instance'\n  xsi:schemaLocation=\"http://www.sitemaps.org/schemas/sitemap/0.9\n    http://www.sitemaps.org/schemas/sitemap/0.9/sitemap.xsd\"\n  xmlns='http://www.sitemaps.org/schemas/sitemap/0.9'\n  xmlns:geo='http://www.google.com/geo/schemas/sitemap/1.0'\n  xmlns:news='http://www.google.com/schemas/sitemap-news/0.9'\n  xmlns:image='http://www.google.com/schemas/sitemap-image/1.1'\n  xmlns:video='http://www.google.com/schemas/sitemap-video/1.1'\n  xmlns:mobile='http://www.google.com/schemas/sitemap-mobile/1.0'\n  xmlns:pagemap='http://www.google.com/schemas/sitemap-pagemap/1.0'\n  xmlns:xhtml='http://www.w3.org/1999/xhtml'\n>\n<url>\n\t<loc>https://example.com/</loc> ...
```


---

This PR fixes this by writing the sitemap to disk in `:utf8` mode ([Source](https://stackoverflow.com/questions/37970230/no-translation-error-while-attempting-to-write-unicode-characters-to-file-in-eli)).
