### PR TITLE
Add OTP 20 to Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,18 @@
 language: elixir
 
 elixir:
-  - 1.3.4
-  - 1.4.4
+  - 1.3
+  - 1.4
 
 otp_release:
   - 18.3
   - 19.3
+  - 20.0
+
+matrix:
+  exclude:
+    - elixir: 1.3
+      otp_release: 20.0
 
 before_install:
   - sudo apt-get update -qq


### PR DESCRIPTION
Hi, a small update to support OTP 20 plus remove the exact version of Elixir so that any patch updates to that release are automatically used. 