### PR TITLE
No need to explicitly add to applications list

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,13 +23,7 @@ If [available in Hex](https://hex.pm/docs/publish), the package can be installed
   end
   ```
 
-  2. Ensure sitemap is started before your application:
-
-  ```elixir
-  def application do
-    [applications: [:sitemap]]
-  end
-  ```
+  2. run `mix deps.get`
 
 #### Usage
 


### PR DESCRIPTION
Every application listed in 'deps' is automatically started as a
dependency by default.

See https://www.amberbit.com/blog/2017/9/22/elixir-applications-vs-extra_applications-guide/