### PR TITLE
Update key for starting the OTP application

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ If [available in Hex](https://hex.pm/docs/publish), the package can be installed
 
   ```elixir
   def application do
-    [applications: [:sitemap]]
+    [extra_applications: [:sitemap]]
   end
   ```
 


### PR DESCRIPTION
Now the key should be `:extra_applications` instead of `:applications` (See https://hexdocs.pm/mix/Mix.Tasks.Compile.App.html)