### PR TITLE
Google requires an xmlns for PageMap

### DIFF
--- a/lib/sitemap/builders/url.ex
+++ b/lib/sitemap/builders/url.ex
@@ -1,6 +1,7 @@
 defmodule Sitemap.Builders.Url do
   alias Sitemap.Funcs
   alias Sitemap.Config
+  alias Sitemap.Consts
   import XmlBuilder
 
   def to_xml(link, attrs \\ []) do
@@ -201,6 +202,7 @@ defmodule Sitemap.Builders.Url do
   defp pagemap(data) do
     element(
       :PageMap,
+      %{xmlns: Consts.schemas.pagemap},
       Enum.map(data[:dataobjects] || [], fn obj ->
         element(
           :DataObject,

--- a/mix.exs
+++ b/mix.exs
@@ -11,6 +11,7 @@ defmodule Sitemap.Mixfile do
       name: "Sitemap",
       version: "1.1.0",
       elixir: ">= 1.3.0",
+      elixirc_paths: elixirc_paths(Mix.env()),
       description: @description,
       build_embedded: Mix.env() == :prod,
       start_permanent: Mix.env() == :prod,
@@ -19,6 +20,9 @@ defmodule Sitemap.Mixfile do
       source_url: "https://github.com/ikeikeikeike/sitemap"
     ]
   end
+
+  defp elixirc_paths(:test), do: ["lib", "test/support"]
+  defp elixirc_paths(_), do: ["lib"]
 
   # Configuration for the OTP application
   #

--- a/test/sitemap/builders_url_test.exs
+++ b/test/sitemap/builders_url_test.exs
@@ -5,6 +5,7 @@ defmodule Sitemap.BuildersUrlTest do
 
   alias Sitemap.Builders.Url
   import SweetXml
+  import Sitemap.XpathNamespace
   require XmlBuilder
 
   setup do
@@ -498,6 +499,7 @@ defmodule Sitemap.BuildersUrlTest do
     assert xpath(parsed, ~x"//PageMap/DataObject/@type") == 'document'
     assert xpath(parsed, ~x"//PageMap/DataObject/Attribute/text()") == 'Dragon'
     assert xpath(parsed, ~x"//PageMap/DataObject/Attribute/@name") == 'name'
+    assert xpath_namespace(parsed, ~x"//PageMap")  == Sitemap.Consts.schemas.pagemap
   end
 
   test "date and datetime convert to iso8601" do

--- a/test/support/xpath_namespace.ex
+++ b/test/support/xpath_namespace.ex
@@ -1,0 +1,13 @@
+defmodule Sitemap.XpathNamespace do
+  import SweetXml
+
+  def xpath_namespace(parsed, spec) do
+    parsed
+    |> xpath(spec)
+    |> xpath(~x"//namespace::*[name()='']")
+    |> case do
+      {_, _, _, _, namespace} -> to_string(namespace)
+      _ -> nil
+    end
+  end
+end


### PR DESCRIPTION
Hey there,

Thanks a lot for bringing sitemaps to elixir!
I was trying to generate a `PageMap` and validate it in the google search console but faced the infamous error message: 

> Incorrect namespace - Your Sitemap or Sitemap index file doesn't properly declare the namespace.
> 
> Parent tag:
> url
> Tag:
> PageMap

In Google examples, they always use the xmlns tags for `PageMap`s, so I gave it a try and was able to import the sitemap after that.
Please find bellow the implementation of attaching the schema to the `PageMap` tag.

Cheers,
Alexander